### PR TITLE
Add schema validation when loading the xml file

### DIFF
--- a/controller/DataBaseSetup.py
+++ b/controller/DataBaseSetup.py
@@ -356,7 +356,6 @@ class DataBaseSetup(object):
                 session.close()
 
 if __name__ == '__main__':
-    # get the latest xml data and get it into an xmltree object
     start_time = time.time()
     log.info('Starting data import...')
 

--- a/controller/ODSFileManager.py
+++ b/controller/ODSFileManager.py
@@ -1,4 +1,5 @@
 from lxml import etree as xml_tree_parser
+import lxml
 import os.path
 import sys
 import zipfile
@@ -15,6 +16,7 @@ log.addHandler(ch)
 class ODSFileManager(object):
 
     __ods_xml_data = None
+    __ods_schema = None
 
     def __init__(self):
         pass
@@ -38,8 +40,32 @@ class ODSFileManager(object):
         # such time it is published and retrievable
         if os.path.isfile('data/HSCOrgRefData_Full_20151130.xml.zip'):
             return 'data/HSCOrgRefData_Full_20151130.xml.zip'
+        # if os.path.isfile('data/test.xml.zip'):
+        #     return 'data/test.xml.zip'
         else:
             raise ValueError('unable to locate the data file')
+
+
+    def retrieve_latest_schema(self):
+        """Get the latest XSD for the ODS XML data and return it as an XMLSchema object
+
+        Parameters
+        ----------
+        None
+
+        Returns
+        -------
+        xml_schema: the ODS XSD as an XMLSchema object
+        """
+        # TODO: Retrieve latest schema file from the local directory until
+        # such time it is published and retrievable
+        try:
+            with open('data/HSCOrgRefData.xsd') as f:
+                doc = xml_tree_parser.parse(f)
+                return xml_tree_parser.XMLSchema(doc)
+
+        except Exception as e:
+            raise
 
     # The purpose of this function is to determine if we have a zip
     # for or xml file, check it is valid
@@ -67,9 +93,26 @@ class ODSFileManager(object):
 
                 with local_zipfile.open(data_filename) as local_datafile:
                     self.__ods_xml_data = xml_tree_parser.parse(local_datafile)
+
         except:
             print('Unexpected error:', sys.exc_info()[0])
             raise
+
+    def __validate_xml_against_schema(self):
+        try:
+            doc = self.__ods_xml_data
+            schema = self.__ods_schema
+            valid = schema.validate(doc)
+
+            if not valid:
+                raise Exception("XML file is not valid against the schema")
+
+            else:
+                return valid
+
+        except Exception as e:
+            raise
+            sys.exit(1)
 
     def get_latest_xml(self):
         """The purpose of this function is to check if we have odsxml data
@@ -84,8 +127,12 @@ class ODSFileManager(object):
         xml_tree_parser: containing the entire xml dataset
         """
 
+        if self.__ods_schema is None:
+            self.__ods_schema = self.retrieve_latest_schema()
+
         if self.__ods_xml_data is None:
             data_filename = self.__retrieve_latest_datafile()
             self.__import_latest_datafile(data_filename)
+            self.__validate_xml_against_schema()
 
         return self.__ods_xml_data


### PR DESCRIPTION
@tonyyates Another one please :)

This now loads the XML schema file from the same directory as the data and validates the XML against the schema before proceeding with the import.

If the XML isn't valid it throws an exception and ends the import routine with an exit code of 1.