### PR TITLE
Replace API docs with proper documentation pages.

### DIFF
--- a/openods_api/routes.py
+++ b/openods_api/routes.py
@@ -35,13 +35,31 @@ def tryit_page():
     return render_template('tryit.html')
 
 
-@app.route('/documentation')
-def documentation():
+@app.route('/apidoc')
+def apidoc():
     """
 
     Returns API documentation as HTML
     """
     return auto.html()
+
+
+@app.route('/documentation')
+def template_documentation():
+    """
+
+    Returns API documentation as HTML
+    """
+    return render_template('getting_started.html')
+
+
+@app.route('/resources')
+def template_resources():
+    """
+
+    Returns API documentation as HTML
+    """
+    return render_template('resources.html')
 
 
 @auto.doc()
@@ -163,7 +181,6 @@ def get_organisation(ods_code):
         return "Not found", status.HTTP_404_NOT_FOUND
 
 
-@auto.doc()
 @app.route("/api/organisations/search/<search_text>", methods=['GET'])
 @ocache.cache.cached(timeout=config.CACHE_TIMEOUT, key_prefix=ocache.generate_cache_key)
 def search_organisations(search_text):

--- a/openods_api/routes.py
+++ b/openods_api/routes.py
@@ -50,7 +50,7 @@ def template_documentation():
 
     Returns API documentation as HTML
     """
-    return render_template('getting_started.html')
+    return render_template('documentation.html')
 
 
 @app.route('/resources')

--- a/openods_api/static/css/main.css
+++ b/openods_api/static/css/main.css
@@ -4,11 +4,12 @@
    Author's custom styles
    ========================================================================== */
 
-
-
-
-
-
+a.anchor {
+    display: block;
+    position: relative;
+    top: -50px;
+    visibility: hidden;
+}
 
 
 

--- a/openods_api/templates/base.html
+++ b/openods_api/templates/base.html
@@ -28,7 +28,7 @@
             <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->
     <nav class="navbar navbar-inverse navbar-fixed-top" role="navigation">
-      <div class="container">
+      <div class="container-fluid">
         <div class="navbar-header">
           <button type="button" class="navbar-toggle collapsed" data-toggle="collapse" data-target="#navbar" aria-expanded="false" aria-controls="navbar">
             <span class="sr-only">Toggle navigation</span>
@@ -47,7 +47,7 @@
 
       <hr>
       <footer>
-        <div class="container">
+        <div class="container-fluid">
             <p><a href="http://github.com/open-ods/open-ods">Open source </a>under the <a href="https://tldrlegal.com/license/mit-license">MIT License (MIT)</a></p>
           <p>Copyright &copy; Open-ODS 2015 </p>
         </div>

--- a/openods_api/templates/documentation.html
+++ b/openods_api/templates/documentation.html
@@ -8,8 +8,10 @@
     <h4>Getting Started</Started></h4>
     <ul class="list-group">
         <li class="list-group-item"><a href="#intro">Introduction</a></li>
+        <li class="list-group-item"><a href="#endpoint">Endpoint</a></li>
         <li class="list-group-item"><a href="#rate">Rate Limiting</a></li>
         <li class="list-group-item"><a href="#auth">Authentication</a></li>
+        <li class="list-group-item"><a href="#versioning">Versioning</a></li>
         <li class="list-group-item"><a href="#paging">Paging</a></li>
         <li class="list-group-item"><a href="#responses">Responses</a></li>
 
@@ -25,13 +27,23 @@
     <p>OpenODS is a data API built following REST principles using open access NHS organisational data from the NHS Organisation Data Service (ODS).</p>
     <p>Please feel free to use OpenODS to support your projects as you like - all we ask is that you give us feedback and contribute any suggestions you might have to help us to continuously improve it.</p>
 
+    <a class="anchor" id="endpoint"></a>
+    <h2>Endpoint</h2>
+    <p>OpenODS API can be accessed at the following endpoint:</p>
+    <code>www.openods.co.uk/api</code>
+
     <a class="anchor" id="rate"></a>
     <h2 >Rate Limiting</h2>
     <p>We don't apply rate-limiting to client requests as we don't see enough traffic at this point in time - but please do be considerate and avoid inadvertent DOS attacks :)</p>
 
     <a class="anchor" id="auth"></a>
     <h2 >Authentication</h2>
-    OpenODS is a completely open API. No authentication is required to access data via the API.
+    No authentication is required to access data via the OpenODS API.
+
+    <a class="anchor" id="versioning"></a>
+    <h2>Versioning</h2>
+    <p>Whilst in Alpha, the API does not use any form of versioning. Breaking changes may be made to the API although we will try and avoid this where not necessary.</p>
+    <p>In the future, we will look to introduce versioned endpoints to handle backwards-incompatible changes.</p>
 
     <a class="anchor" id="paging"></a>
     <h2>Pagination</h2>

--- a/openods_api/templates/getting_started.html
+++ b/openods_api/templates/getting_started.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container-fluid">
+<div class="row">
+<div class="col-sm-2 col-md-2">
+    <h4>Getting Started</Started></h4>
+    <ul class="list-group">
+        <li class="list-group-item"><a href="#intro">Introduction</a></li>
+        <li class="list-group-item"><a href="#rate">Rate Limiting</a></li>
+        <li class="list-group-item"><a href="#auth">Authentication</a></li>
+        <li class="list-group-item"><a href="#paging">Paging</a></li>
+        <li class="list-group-item"><a href="#responses">Responses</a></li>
+
+    </ul>
+    <!--<h4>Resources</h4>-->
+    <ul class="list-group">
+        <li class="list-group-item"><a href="/resources">Resources</a></li>
+    </ul>
+</div>
+<div class="col-sm-10 col-md-10">
+    <a class="anchor" id="intro"></a>
+    <h2 >Introduction</h2>
+    <p>OpenODS is a data API built following REST principles using open access NHS organisational data from the NHS Organisation Data Service (ODS).</p>
+    <p>Please feel free to use OpenODS to support your projects as you like - all we ask is that you give us feedback and contribute any suggestions you might have to help us to continuously improve it.</p>
+
+    <a class="anchor" id="rate"></a>
+    <h2 >Rate Limiting</h2>
+    <p>We don't apply rate-limiting to client requests as we don't see enough traffic at this point in time - but please do be considerate and avoid inadvertent DOS attacks :)</p>
+
+    <a class="anchor" id="auth"></a>
+    <h2 >Authentication</h2>
+    OpenODS is a completely open API. No authentication is required to access data via the API.
+
+    <a class="anchor" id="paging"></a>
+    <h2>Pagination</h2>
+    <p>Pagination can be used on routes which return multiple instances of a resource (e.g. <code>/organisations</code>) by using the <code>offset</code> and <code>limit</code> query parameters to page the results returned.
+    <p>Responses containing multiple resources will include a <code>X-Total-Count</code> header with the total number of resources available.
+    <p><em>At some point in the future we'll add prev / next headers to make paging through results easier but for the moment you will need to track yourself using the <code>X-Total-Count</code> header.</em>
+
+   <a class="anchor" id="responses"></a>
+    <h2>Responses</h2>
+    <p>As you can only do GET requests against the API currently there are only a couple of response codes you can expect to receive.
+    <ul>
+        <li><code>200 OK</code> - Will be returned when a request is successful. The body will either contain a single resource object, or a list of resource objects. In the event of no results (e.g. on a request with query parameters <code>/organisations?q=chocolate</code> request), a <code>200</code> with an empty list will be returned.
+        <li><code>404 NOT FOUND</code> - Will be returned when a request is unsuccessful. This will normally occur when trying to GET a single resource e.g. <code>/organisations/RFF</code>
+    </ul>
+
+</div>
+</div>
+</div>
+{% endblock %}

--- a/openods_api/templates/index.html
+++ b/openods_api/templates/index.html
@@ -3,7 +3,7 @@
 {% block content %}
 
     <div class="jumbotron">
-      <div class="container">
+      <div class="container-fluid">
         <h1>OpenODS [ALPHA] {% if live_deployment == 'FALSE' %}[{{ instance_name }}]{% endif %}</h1>
         <p><b>A friendly API for the structure of the NHS</b> based firmly on the principle <em>"Make things open: it makes them better"</em></p>
             <p></p>
@@ -11,7 +11,7 @@
       </div>
     </div>
 
-    <div class="container">
+    <div class="container-fluid">
       <!-- Example row of columns -->
       <div class="row">
         <div class="col-md-4">

--- a/openods_api/templates/resources.html
+++ b/openods_api/templates/resources.html
@@ -1,0 +1,226 @@
+{% extends "base.html" %}
+
+{% block content %}
+
+<div class="container-fluid">
+<div class="row">
+<div class="col-sm-2 col-md-2">
+    <h4>Resources</h4>
+    <ul class="list-group">
+        <li class="list-group-item"><a href="#root">Root</a></li>
+        <li class="list-group-item"><a href="#info">Info</a></li>
+        <li class="list-group-item"><a href="#organisations">Organisations</a></li>
+    </ul>
+    <ul class="list-group">
+        <li class="list-group-item"><a href="/documentation">Getting Started</a></li>
+    </ul>
+</div>
+<div class="col-sm-10 col-md-10">
+    <a class="anchor" id="resources"></a>
+    <h2>Resources</h2>
+
+    <div class="openods-resource">
+    <a class="anchor" id="root"></a>
+    <h3>Root</h3>
+    <p>The Root resource provides information about all available resources through the API.</p>
+    <b>Example HTTP Request:</b>
+    <pre>http://wwww.openods.co.uk/api</pre>
+    <b>Example Response:</b>
+    <pre>
+HTTP/1.0 200 OK
+Content-Type: application/json
+{
+  "organisations": "http://www.openods.co.uk/api/organisations",
+  "role-types": "http://www.openods.co.uk/api/role-types"
+}
+    </pre>
+    <b>Attributes:</b>
+    <ul>
+        <li><code>organisations</code><em>string</em> - The URL root for Organisation resources</li>
+        <li><code>role-types</code><em>string</em> - The URL root for Role-Type resources</li>
+    </ul>
+    </div>
+
+    <div class="openods-resource">
+    <a class="anchor" id="info"></a>
+    <h3>Info</h3>
+    <p>The Info resource returns metadata about the source ODS data currently being served by the API.</p>
+    <b>Example HTTP Request:</b>
+    <pre>http://wwww.openods.co.uk/api/info</pre>
+    <b>Example Response:</b>
+    <pre>
+HTTP/1.0 200 OK
+Content-Type: application/json
+{
+  "fileVersion": "1.0.0",
+  "importTimestamp": "2015-12-11 09:05:30.916881",
+  "publicationDate": "2015-11-30",
+  "publicationSeqNo": "1",
+  "publicationType": "Full"
+}
+    </pre>
+    <b>Attributes:</b>
+    <ul>
+        <li><code>fileVersion</code><em>string</em> - The version of the file containing the source data used to populate to <OpenODS class=""></OpenODS></li>
+        <li><code>importTimestamp</code><em>string</em> - The timestamp representing when the current data was imported into the OpenODS database.</li>
+        <li><code>publicationDate</code><em>string</em> - The publication date of the current data.</li>
+        <li><code>publicationSeqNo</code><em>string</em> - The publication sequence number of the current data.</li>
+        <li><code>publicationType</code><em>string</em> - The publication type of the current data (this will almost always be <code>Full</code>.</li>
+    </ul>
+    </div>
+
+    <div class="openods-resource">
+    <a class="anchor" id="organisations"></a>
+    <h3>Organisations</h3>
+    <p>An Organisation resource is a single organisation within ODS.</p>
+    <b>Endpoints:</b>
+        <ul>
+            <li><code>/organisations</code><em>string</em> - get all the Organisation resources (will return a list of 'summary' resource records).</li>
+            <li><code>/organisations/:odsCode</code><em>string</em> - get a specific Organisation resource by its ODS code (will return the full resource).</li>
+        </ul>
+    <b>Query Parameters:</b>
+        <ul>
+            <li><code>q</code><em>string</em> - Filter results to those containing specified string in their name attribute</li>
+            <li><code>offset</code><em>integer</em> - Return results offset by specified number</li>
+            <li><code>limit</code><em>integer</em> - Limit number of results returned to specified number</li>
+            <li><code>recordClass</code><em>string</em> - Filter results by their record class (HSCOrg or HSCSite)</li>
+            <li><code>roleCode</code><em>string</em> - Filter results to only those which have the specified role</li>
+            <li><code>primaryRoleCode</code><em>string</em> - Filter results to only those which have the specified primary role (ignored if roleCode is also specified)</li>
+        </ul>
+
+    <br>
+    <b>Example HTTP Request:</b>
+    <pre>http://www.openods.co.uk/api/organisations?q=barnsley&limit=10&roleCode=RO197</pre>
+    <b>Example Response:</b>
+        <pre>
+HTTP/1.0 200 OK
+Content-Type: application/json
+{
+  "organisations": [
+    {
+      "links": [
+        {
+          "href": "http://www.openods.co.uk/api/organisations/RFF",
+          "rel": "self"
+        }
+      ],
+      "name": "BARNSLEY HOSPITAL NHS FOUNDATION TRUST",
+      "odsCode": "RFF",
+      "recordClass": "HSCOrg"
+    }
+  ]
+}
+        </pre>
+        <br>
+    <b>Example HTTP Request:</b>
+    <pre>http://www.openods.co.uk/api/organisations/RFF</pre>
+    <b>Example Response:</b>
+    <pre>
+HTTP/1.0 200 OK
+Content-Type: application/json
+{
+  "name": "BARNSLEY HOSPITAL NHS FOUNDATION TRUST",
+  "odsCode": "RFF",
+  "operationalStartDate": "2002-03-31",
+  "recordClass": "HSCOrg",
+  "refOnly": false,
+  "addresses": [
+    {
+      "address": {
+        "country": "ENGLAND",
+        "county": "SOUTH YORKSHIRE",
+        "postcalCode": "S75 2EP",
+        "streetAddressLine1": "GAWBER ROAD",
+        "town": "BARNSLEY"
+      }
+    }
+  ],
+  "last_changed": "2015-05-26",
+  "legalStartDate": "1993-04-01",
+  "links": [
+    {
+      "href": "http://www.openods.co.uk/api/organisations/RFF",
+      "rel": "self"
+    }
+  ],
+  "relationships": [
+    {
+      "relationship": {
+        "code": "RE1",
+        "description": "HAS A LEGACY RELATIONSHIP TO",
+        "links": [
+          {
+            "href": "http://www.openods.co.uk/api/organisations/Y02",
+            "rel": "related-organisation"
+          }
+        ],
+        "operationalEndDate": "2002-03-31",
+        "operationalStartDate": "1993-04-01",
+        "relatedOdsCode": "Y02",
+        "relatedOrganisationName": "TRENT REGIONAL OFFICE",
+        "status": "Inactive",
+        "uniqueId": 13388
+      }
+    }
+  ],
+  "roles": [
+    {
+      "role": {
+        "code": "RO197",
+        "description": "NHS TRUST",
+        "links": [
+          {
+            "href": "http://www.openods.co.uk/api/role-types/RO197",
+            "rel": "role-type"
+          }
+        ],
+        "operationalStartDate": "1993-04-01",
+        "primaryRole": true,
+        "status": "Active",
+        "uniqueId": 126697
+      }
+    }
+  ],
+  "status": "Active",
+  "successors": [
+    {
+      "successor": {
+        "links": [
+          {
+            "href": "http://www.openods.co.uk/api/organisations/CJA",
+            "rel": "predecessor"
+          }
+        ],
+        "targetOdsCode": "CJA",
+        "targetprimaryrolecode": "RO111",
+        "type": "Predecessor",
+        "uniqueId": 11545
+      }
+    }
+  ]
+}
+    </pre>
+    <b>Attributes:</b>
+    <ul>
+        <li><code>name</code><em>string</em> - The name of this organisation.</li>
+        <li><code>odsCode</code><em>string</em> - The ODS code of this organisation.</li>
+        <li><code>last_changed</code><em>string</em> - The date on which this organisation record was list updated.</li>
+        <li><code>operationalStartDate</code><em>string</em> - The Operational Start Date for this organisation.</li>
+        <li><code>operationalEndDate</code><em>string</em> - The Operational End Date for this organisation.</li>
+        <li><code>legalStartDate</code><em>string</em> - The Legal End Date for this organisation.</li>
+        <li><code>legalEndDate</code><em>string</em> - The Legal End Date for this organisation.</li>
+        <li><code>recordClass</code><em>string</em> - The record class of the organisation - currently either HSCOrg or HSCSite.</li>
+        <li><code>refOnly</code><em>boolean</em> - Whether the record is included just for reference (will soon be moved to archived data).</li>
+        <li><code>status</code><em>string</em> - The status of this organisation record - either <code>Active</code> or <code>Inactive</code></li>
+        <li><code>addresses</code><em>array</em> - An array of address objects related to this organisation record.</li>
+        <li><code>relationships</code><em>array</em> - An array of relationship objects related to this organisation record.</li>
+        <li><code>roles</code><em>array</em> - An array of role objects related to this organisation record.</li>
+        <li><code>successors</code><em>array</em> - An array of successor objects related to this organisation record.</li>
+        <li><code>links</code><em>array</em> - An array of hypermedia links relevant to this resource.</li>
+
+    </ul>
+    </div>
+</div>
+</div>
+</div>
+{% endblock %}

--- a/openods_api/templates/tryit.html
+++ b/openods_api/templates/tryit.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-
+<div class="container-fluid">
 <div class="row">
           <hr>
     <div class="col-sm-2 col-lg-2 col-md-2">
@@ -57,6 +57,7 @@
         </div>
     </div>
     <div class="col-sm-2 col-lg-2 col-md-2">
+    </div>
     </div>
 {% endblock %}
 


### PR DESCRIPTION
/documentation now gives a new HTML documentation page.
Also changed a couple of routes in routes.py.
/apidoc will now give the old documentation page.
Changed all the container classes to container-fluid in the templates.

<!---
@huboard:{"order":56.0,"milestone_order":56,"custom_state":""}
-->
